### PR TITLE
"click_marketplace_post_purchase" 이벤트 제거

### DIFF
--- a/data/required_event_list.json
+++ b/data/required_event_list.json
@@ -550,11 +550,6 @@
     "created_date": "2023-07-20"
   },
   {
-    "event_name": "click_marketplace_post_purchase",
-    "event_type": "auto sync",
-    "created_date": "2023-07-20"
-  },
-  {
     "event_name": "click_marketplace_post_share",
     "event_type": "auto sync",
     "created_date": "2023-07-20"


### PR DESCRIPTION
작업내용
- `click_marketplace_post_purchase` 이벤트명을 제거하고, 기존에 사용중이던 `direct_deal_page_click` 이벤트에 `button` 파라미터를 추가해서 수집하도록 변경했습니다.
- https://github.com/green-labs/farmmorning-app/pull/2502#discussion_r1383137477

- https://greenlabs-group.slack.com/archives/C05B9KGTBUM/p1699259206460839?thread_ts=1698913603.011049&cid=C05B9KGTBUM