### PR TITLE
remove: 채팅 이벤트 제거

### DIFF
--- a/data/required_event_list.json
+++ b/data/required_event_list.json
@@ -195,11 +195,6 @@
     "created_date": "2023-06-14"
   },
   {
-    "event_name": "direct_deal_chatbutton",
-    "event_type": "직거래장터 탭",
-    "created_date": "2023-06-14"
-  },
-  {
     "event_name": "direct_deal_page_click",
     "event_type": "직거래장터 탭",
     "created_date": "2023-06-14"

--- a/data/test.json
+++ b/data/test.json
@@ -95,11 +95,6 @@
     "created_date": "2023-06-15"
   },
   {
-    "event_name": "direct_deal_chatbutton",
-    "event_type": "auto sync",
-    "created_date": "2023-06-15"
-  },
-  {
     "event_name": "direct_deal_post_submit",
     "event_type": "auto sync",
     "created_date": "2023-06-15"


### PR DESCRIPTION
작업내용
-
- `direct_deal_chatbutton`

장터의 판매글에서 채팅 기능이 사라지면서 해당 이벤트를 제거합니다.

<img width="610" alt="image" src="https://github.com/green-labs/data-dev-interaction/assets/46080627/1d5bf261-b39a-454f-95b9-cd7f0fa2dfc9">


